### PR TITLE
feat: add RFC 9421 tracker; closes #64

### DIFF
--- a/RFC9421.md
+++ b/RFC9421.md
@@ -1,0 +1,75 @@
+# RFC 9421 Adoption
+
+This document tracks adoption of RFC 9421 on the Fediverse.
+
+## Adoption matrix
+
+| Software | Accept for GET | Accept for POST | Send for GET | Send for POST | Issue |
+| -------- | -------------- | --------------- | ------------ | -------- | ----- |
+| [Activity-Relay](https://relay.toot.yukimochi.jp) | ? | ? | ? | ? | ? |
+| [activitypub.bot](https://github.com/evanp/activitypub-bot) | Y | Y | Double-knock | Double-knock | [#176](https://github.com/evanp/activitypub-bot/issues/176) |
+| [Activityrelay](https://git.pleroma.social/pleroma/relay) | ? | ? | ? | ? | ? |
+| [Akkoma](https://akkoma.dev/AkkomaGang/akkoma) | ? | ? | ? | ? | ? |
+| [BadgeFed](https://badgefed.org) | ? | ? | ? | ? | ? |
+| [Betula](https://betula.mycorrhiza.wiki) | ? | ? | ? | ? | ? |
+| [Bonfire](https://bonfirenetworks.org) | ? | ? | ? | ? | ? |
+| [Bookwyrm](https://joinbookwyrm.com) | ? | ? | ? | ? | ? |
+| [Bridgy-fed](https://fed.brid.gy) | ? | ? | ? | ? | ? |
+| [Cherrypick](https://github.com/kokonect-link/cherrypick) | ? | ? | ? | ? | ? |
+| [Drupal](https://www.drupal.org/project/activitypub) | ? | ? | ? | ? | ? |
+| [Ecko](https://magicstone.dev) | ? | ? | ? | ? | ? |
+| [Emissary](https://emissary.dev) | ? | ? | ? | ? | ? |
+| [Fedibird](https://github.com/fedibird/mastodon) | ? | ? | ? | ? | ? |
+| [Firefish](https://fedidb.com/software/firefish) | ? | ? | ? | ? | ? |
+| [Forgejo](https://fedidb.com/software/forgejo) | ? | ? | ? | ? | ? |
+| [Foundkey](https://akkoma.dev/FoundKeyGang/FoundKey) | ? | ? | ? | ? | ? |
+| [frequency](https://frequency.app) | ? | ? | ? | ? | ? |
+| [Friendica](https://friendi.ca) | ? | ? | ? | ? | ? |
+| [Funkwhale](https://funkwhale.audio) | ? | ? | ? | ? | ? |
+| [Gancio](https://gancio.org) | ? | ? | ? | ? | ? |
+| [Ghost](https://ghost.org) | ? | ? | ? | ? | ? |
+| [GNU social](https://gnusocial.network) | ? | ? | ? | ? | ? |
+| [Gotosocial](https://gotosocial.org) | ? | ? | ? | ? | ? |
+| [Hackers' Pub](https://hackers.pub/) | ? | ? | ? | ? | ? |
+| [Hollo](https://docs.hollo.social) | ? | ? | ? | ? | ? |
+| [Hometown](https://github.com/hometown-fork/hometown) | ? | ? | ? | ? | ? |
+| [Honk](https://fedidb.com/software/honk) | ? | ? | ? | ? | ? |
+| [Hubzilla](https://hubzilla.org) | ? | ? | ? | ? | ? |
+| [Iceshrimp](https://iceshrimp.dev/iceshrimp/iceshrimp) | ? | ? | ? | ? | ? |
+| [irwin](https://otisburg.social) | ? | ? | ? | ? | ? |
+| [Kmyblue](https://github.com/kmycode/mastodon) | ? | ? | ? | ? | ? |
+| [Ktistec](https://github.com/toddsundsted/ktistec) | ? | ? | ? | ? | ? |
+| [Lemmy](https://join-lemmy.org) | ? | ? | ? | ? | ? |
+| [Loops](https://joinloops.org) | ? | ? | ? | ? | ? |
+| [Lotide](https://git.sr.ht/~vpzom/lotide) | ? | ? | ? | ? | ? |
+| [Manyfold](https://manyfold.app) | ? | ? | ? | ? | ? |
+| [Mastodon](https://joinmastodon.org) | Y | Y | N [^1] |  N [^1] | [29905](https://github.com/mastodon/mastodon/issues/29905) |
+| [Mbin](https://joinmbin.org/) | ? | ? | ? | ? | ? |
+| [Meisskey](https://github.com/mei23/misskey) | ? | ? | ? | ? | ? |
+| [Microblogpub](https://microblog.pub) | ? | ? | ? | ? | ? |
+| [Microdotblog](https://micro.blog) | ? | ? | ? | ? | ? |
+| [Misskey](https://misskey-hub.net) | ? | ? | ? | ? | ? |
+| [Mitra](https://codeberg.org/silverpill/mitra) | ? | ? | ? | ? | ? |
+| [Mobilizon](https://joinmobilizon.org) | ? | ? | ? | ? | ? |
+| [murlog](https://murlog.org) | ? | ? | ? | ? | ? |
+| [NeoDB](https://neodb.net) | ? | ? | ? | ? | ? |
+| [NodeBB](https://nodebb.org) | ? | ? | ? | ? | ? |
+| [Owncast](https://owncast.online) | ? | ? | ? | ? | ? |
+| [PeerTube](https://joinpeertube.org) | ? | ? | ? | ? | ? |
+| [Piefed](https://join.piefed.social) | ? | ? | ? | ? | ? |
+| [Pixelfed](https://pixelfed.org) | ? | ? | ? | ? | ? |
+| [Pleroma](https://pleroma.social) | ? | ? | ? | ? | ? |
+| [Plume](https://joinplu.me) | ? | ? | ? | ? | ? |
+| [Postmarks](https://postmarks.glitch.me) | ? | ? | ? | ? | ? |
+| [Sharkey](https://joinsharkey.org) | ? | ? | ? | ? | ? |
+| [Smithereen](https://smithereen.software) | ? | ? | ? | ? | ? |
+| [Snac](https://codeberg.org/grunfink/snac2) | ? | ? | ? | ? | ? |
+| [stegodon](https://stegodon.social) | ? | ? | ? | ? | ? |
+| [Takahe](https://jointakahe.org) | ? | ? | ? | ? | ? |
+| [Vernissage](https://vernissage.photos/home) | ? | ? | ? | ? | ? |
+| [wafrn](https://wafrn.net) | ? | ? | ? | ? | ? |
+| [WordPress](https://wordpress.org) | ? | ? | ? | ? | ? |
+| [WriteFreely](https://writefreely.org) | ? | ? | ? | ? | ? |
+| [Zap](https://codeberg.org/zot-archive/zap) | ? | ? | ? | ? | ? |
+
+[^1]: Added in 4.7.0. Double-knock, but uses draft-cavage-12 first. https://github.com/mastodon/mastodon/pull/39756


### PR DESCRIPTION
This PR adds a Markdown file to track ActivityPub software implementations of RFC 9421.