### PR TITLE
Track RFC 9421 support inherited from Fedify

### DIFF
--- a/RFC9421.md
+++ b/RFC9421.md
@@ -49,11 +49,11 @@ Thanks to [FediDB](https://fedidb.com/software) for the seed version of the soft
 | [Friendica](https://friendi.ca) | ? | ? | ? | ? | ? |
 | [Funkwhale](https://funkwhale.audio) | ? | ? | ? | ? | ? |
 | [Gancio](https://gancio.org) | ? | ? | ? | ? | ? |
-| [Ghost](https://ghost.org) | ? | ? | ? | ? | ? |
+| [Ghost](https://ghost.org) | ✅ Y | ✅ Y | ✅ Y [^2] | ✅ Y [^2] | [Fedify #208](https://github.com/fedify-dev/fedify/issues/208) |
 | [GNU social](https://gnusocial.network) | ? | ? | ? | ? | ? |
 | [Gotosocial](https://gotosocial.org) | ❌ N | ❌ N | ❌ N | ❌ N | [4939](https://codeberg.org/superseriousbusiness/gotosocial/issues/4939) |
-| [Hackers' Pub](https://hackers.pub/) | ? | ? | ? | ? | ? |
-| [Hollo](https://docs.hollo.social) | ? | ? | ? | ? | ? |
+| [Hackers' Pub](https://hackers.pub/) | ✅ Y | ✅ Y | ✅ Y [^2] | ✅ Y [^2] | [Fedify #208](https://github.com/fedify-dev/fedify/issues/208) |
+| [Hollo](https://docs.hollo.social) | ✅ Y | ✅ Y | ✅ Y [^2] | ✅ Y [^2] | [Fedify #208](https://github.com/fedify-dev/fedify/issues/208) |
 | [Hometown](https://github.com/hometown-fork/hometown) | ? | ? | ? | ? | ? |
 | [Honk](https://fedidb.com/software/honk) | ? | ? | ? | ? | ? |
 | [Hubzilla](https://hubzilla.org) | ✅ Y | ✅ Y | ✅ Y [^4] | ✅ Y [^4] | N |


### PR DESCRIPTION
Ghost, Hackers' Pub, and Hollo delegate ActivityPub HTTP signing and verification to Fedify. I used that shared layer as the source for all three matrix entries because none maintains a separate HTTP signature stack.

Fedify verifies RFC 9421 signatures on `GET`/`POST` requests and signs outgoing `GET`/`POST` requests with double-knocking for compatibility with servers that still require draft-cavage. *RFC9421.md* links [Fedify #208](https://github.com/fedify-dev/fedify/issues/208) as the common implementation record.
