### PR TITLE
Add Welley to the RFC 9421 adoption matrix

### DIFF
--- a/RFC9421.md
+++ b/RFC9421.md
@@ -92,6 +92,7 @@ Thanks to [FediDB](https://fedidb.com/software) for the seed version of the soft
 | [Threads](https://threads.net/) | ? | ? | ? | ? | ? |
 | [Vernissage](https://vernissage.photos/home) | ? | ? | ? | ? | ? |
 | [wafrn](https://wafrn.net) | ? | ? | ? | ? | ? |
+| [Welley](https://welley.social) | ✅ Y | ✅ Y | ✅ Y [^7] | ✅ Y [^7] | N |
 | [WordPress](https://wordpress.org) | ✅ Y | ✅ Y | ✅ Y [^6] | ✅ Y [^6] | [2859](https://github.com/Automattic/wordpress-activitypub/pull/2859) |
 | [WriteFreely](https://writefreely.org) | ❌ N | ❌ N | ❌ N | ❌ N | [RFC 9421](https://discuss.write.as/t/rfc-9421/20843) |
 
@@ -101,3 +102,4 @@ Thanks to [FediDB](https://fedidb.com/software) for the seed version of the soft
 [^4]: Supports double-knock, capability, and toggle on permanently via config.
 [^5]: Added in 4.7.0. Double-knock, but uses draft-cavage-12 first. [PR](https://github.com/mastodon/mastodon/pull/39756)
 [^6]: As a server configuration option, off by default.
+[^7]: As a server configuration option, off by default. No double-knock yet: turning it on replaces draft-cavage-12 rather than falling back to it. Acceptance of both versions is always on and is independent of the outgoing setting.


### PR DESCRIPTION
Adds [Welley](https://welley.social) to the adoption matrix.

Welley is an ActivityPub server (Kotlin/Quarkus) that adds Groups and Forums on top of Mastodon-compatible federation. Current RFC 9421 status:

**Accept, GET and POST: yes.** Incoming requests are routed by the presence of `Signature-Input`: present selects the RFC 9421 verifier, absent falls back to draft-cavage-12. Acceptance is always on and does not depend on what we send. The profile implemented matches what Mastodon accepts: RSA-SHA256, `@method` and `@target-uri` required as covered components plus `content-digest` on POST, `keyid` and `created` required, first signature label only. RFC 9530 `Content-Digest` is recomputed against the request body and is fail-closed. Signed GET reads go through the same path, not just the inbox.

**Send, GET and POST: yes, but off by default.** RFC 9421 signing is a server configuration option (`activitypub.outgoing-signature-scheme`), defaulting to draft-cavage-12. There is no double-knock yet, so enabling the option replaces draft-cavage-12 rather than falling back to it, which is why it stays off by default. Footnote 7 records this.

**Issues:** we track this in a private tracker, so the column is `N`, matching the other entries without a public issue.

Happy to adjust the send columns to `N` if the convention here is to record only what a server does in its default configuration. I read the WordPress row (footnote 6) as the closest precedent for an off-by-default configuration option being marked `Y`.
